### PR TITLE
Extract WebID Profile into its own sub-spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+##### v0.6.0
+
+- Move overview-type sections to `solid/solid` (see
+  [PR #85](https://github.com/solid/solid-spec/pull/85))
+- Extract and expand the explanation of WebID Profiles to
+  [their own section](solid-webid-profiles.md)
+
 ##### v0.5.0
 
 - Replace Workspaces concept, provide recommendations for

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Disclaimer: this is a living spec. Expect it to change often!**
 
-**Current Spec version:** `v.0.5.0` (see [CHANGELOG.md](CHANGELOG.md))
+**Current Spec version:** `v.0.6.0` (see [CHANGELOG.md](CHANGELOG.md))
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 ## Table of contents
 
 * [Overview](#overview)
+* [Identity](#identity)
 * [Profiles](#profiles)
+  * [WebID Profile Documents](#webid-profile-documents)
 * [Authorization and Access Control](#web-access-control)
 * [Reading](#reading)
 * [Subscribing](#subscribing)
@@ -39,57 +41,42 @@ See Also:
 * [Platform Notes](https://github.com/solid/solid#solid-platform-notes)
 * [Solid Project directory](https://github.com/solid/solid#project-directory)
 
+## Identity
+
+Solid uses [WebID](http://www.w3.org/2005/Incubator/webid/spec/identity/) URIs
+as universal usernames or actor identifiers. Frequently referred to simply as  
+*WebIDs*, these URIs form the basis of most other Solid-related technologies,
+such as authentication, authorization, access control, user profiles, discovery
+of user preferences and server capabilities, and more.
+
+WebIDs provide globally unique decentralized identifiers, enable cross-service
+federated signin, prevent service provider lock-in, and give users control over
+their own identity. *The WebID URI's primary function is to point to the
+location of a public [WebID Profile document](#profiles) (see below).*
+
+**Example WebIDs:** `https://alice.databox.com/profile/card#me` or
+`http://somepersonalsite.com/#webid`
+
 ## Profiles
 
-Identity management as well as unique identifiers are the core of any social
-system. Solid uses
-[WebID](http://www.w3.org/2005/Incubator/webid/spec/identity/), an HTTP(S) URI,
-to uniquely refer to users (people or agents). The advantage of WebID is that
-the URI can be dereferenced to a WebID profile document, in order to reveal
-useful information about the user. Also, since WebID profiles can be hosted
-anywhere (including your basement server), users are no longer trapped inside
-Identity Provider Silos (Twitter, Facebook, Google+, etc.).
+Solid uses WebID Profile Documents for management of user identity and security
+credentials (such as public keys), and user preferences discovery.
 
-The WebID profile document should be the first resource created by the server
-after receiving a request for a new account. The reason is that other resources
-such as the `preferencesFile` document will be linked to from the profile
-document as soon as they are created.
+Although here we mostly refer to them in the context of user profiles,
+other types of actors use these profiles as well, such as groups, organizations,
+devices, and software applications.
 
-The profile document follows the structure and schema described by the
-[WebID spec](http://www.w3.org/2005/Incubator/webid/spec/identity/#publishing-the-webid-profile-document).
-A bare profile document only needs to contain a minimum number of RDF relations,
-such as the ones pointing to the [Default Containers](#default-containers).
-During account creation, the user may provide a full
-name or a profile picture, but those profile elements are not mandatory, and can
-be added in a future request (i.e. through a PATCH).
+### WebID Profile Documents
 
-A typical (bare) profile document (i.e.
-`https://alice.example.org/profile/card`) will look as follows:
+A WebID URI, when dereferenced, yields a WebID Profile Document in a
+Linked Data format ([Turtle]((http://www.w3.org/TR/turtle/) by default, but
+often available as JSON-LD or HTML+RDFa). Parsing this document provides a
+client application with useful information, such as the user's name and
+profile image, links to user preferences and related documents, and lists of
+public key certificates or other relevant identity credentials.
 
-```
-<>
-    a <http://xmlns.com/foaf/0.1/PersonalProfileDocument> ;
-    <http://xmlns.com/foaf/0.1/maker> <#me> ;
-    <http://xmlns.com/foaf/0.1/primaryTopic> <#me> .
-
-<#me>
-    a <http://xmlns.com/foaf/0.1/Person> ;
-    <http://www.w3.org/ns/pim/space#storage> <../> ;
-    <http://www.w3.org/ns/pim/space#preferencesFile> <../settings/preferences.ttl> ;
-```
-
-### Linking the account URI to the user's WebID
-
-An optional, but recommended step in the account creation workflow is to link
-the account (i.e. `https://alice.example.org/`) to the account owner's WebID.
-
-To do that, the server may add a triple to the root container's meta file (i.e.
-`/.meta`), in which it adds the following triple:
-
-```
-<profile/card#me>
-    <http://xmlns.com/foaf/0.1/account> <> .
-```
+**See component spec:
+  [Solid WebID Profiles Specification](solid-webid-profiles.md)**
 
 ### Default Containers
 

--- a/solid-webid-profiles.md
+++ b/solid-webid-profiles.md
@@ -1,0 +1,244 @@
+# Solid WebID Profiles Spec
+
+**Note:** This spec is a component of the parent
+[Solid specification](README.md); the parent spec and all its components are
+versioned as a whole.
+
+## Table of Contents
+
+* [Overview](#overview)
+* [Profile Representation Formats](#profile-representation-formats)
+* [Required Profile Information](#required-profile-information)
+* [Minimum Recommended Profile
+      Information](#minimum-recommended-profile-information)
+    * [Recommendation for User Names in
+      Profiles](#recommendation-for-user-names-in-profiles)
+* [Public and Private Profiles](#public-and-private-profiles)
+* [Public Key Certificates](#public-key-certificates)
+* [Account Resource Discovery](#account-resource-discovery)
+    * [Storage Discovery](#storage-discovery)
+    * [Inbox Discovery](#inbox-discovery)
+    * [Type Registry Index Discovery](#type-registry-index-discovery)
+
+## Overview
+
+Solid uses WebID Profile Documents for management of user identity and security
+credentials (such as public keys), and user preferences discovery.
+
+## Profile Representation Formats
+
+From the
+[WebID Profile](https://www.w3.org/2005/Incubator/webid/spec/identity/#publishing-the-webid-profile-document)
+spec:
+
+> A WebID Profile Document is an RDF Web resource that MUST be available as
+> [text/turtle](http://www.w3.org/TR/turtle/), but MAY be available in other RDF
+> serialization formats (such as JSON-LD or
+> [HTML+RDFa](http://www.w3.org/TR/rdfa-core/)) if requested through content
+> negotiation.
+
+## Required Profile Information
+
+There are only 3 statements required for a valid (though not very useful)
+WebID Profile Document:
+
+1. Identifying the document as a `foaf:PersonalProfileDocument` instance
+2. Having a `foaf:primaryTopic` predicate
+3. Having that primary topic be a valid `foaf:Agent` type, such as `foaf:Person`
+
+Here's an example of a minimum valid profile, in Turtle (`text/turtle`) format:
+
+```
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+<https://alice.databox.com/profile/card>
+    a foaf:PersonalProfileDocument ;
+    foaf:primaryTopic <#me> .
+
+<#me>
+    a foaf:Person .
+```
+
+Same profile, in JSON-LD (`application/ld+json`) format:
+
+```json
+{
+  "@context": {
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@graph": [
+    {
+      "@id": "https://alice.databox.com/profile/card",
+      "@type": "foaf:PersonalProfileDocument",
+      "foaf:primaryTopic": {
+        "@id": "#me"
+      }
+    },
+    {
+      "@id": "#me",
+      "@type": "foaf:Person"
+    }
+  ]
+}
+```
+
+## Minimum Recommended Profile Information
+
+The above minimal valid profile doesn't provide enough useful information
+for the purposes of building distributed read-write-web applications.
+In addition, Solid recommends that WebID profiles include the following
+statements:
+
+1. A profile SHOULD include a `foaf:name` (see the discussion
+  on [user names](#recommendation-for-user-names-in-profiles) below).
+2. A profile SHOULD include `cert:key` public key certificate information, for
+  use with WebID+TLS (which is currently the primary Solid authentication
+  mechanism).
+3. A profile SHOULD point to the root storage location using `pim:storage`
+  (so that applications will know where to read and write their data).
+
+```
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+<https://alice.databox.com/profile/card>
+    a foaf:PersonalProfileDocument ;
+    foaf:primaryTopic <#me> .
+<#me>
+    a foaf:Person ;
+    foaf:name "Alice" ;
+    <http://www.w3.org/ns/auth/cert#key> <#key6b4c> ;
+    <http://www.w3.org/ns/pim/space#storage> <../> ;
+<#key6b4c>
+    # ... certificate key statements go here, see Certificates section
+```
+
+### Recommendation for User Names in Profiles
+
+Client-side applications frequently need to know what to name the user, both
+when interacting with the user directly (such as displaying the currently
+logged in user in the navigation bar), or talking about users indirectly
+(an event manager app, when listing which users are invited to a meeting, needs
+to know how to display their names).
+
+The Solid recommendation for client-side application code, when discovering
+what to name the user, is to perform the following steps:
+
+1. An app SHOULD look in the user's WebID Profile for the `foaf:name` predicate,
+  and use that as the name, if it's available.
+2. If an app does not find a name in the user profile, it MAY fall back to using
+  the WebID URL as the username.
+
+## Public and Private Profiles
+
+Solid servers must be able to support the separation of public and private data
+in a user's profile. As a result, Solid WebID profiles MAY be split into
+multiple RDF resources with different read/write permissions, linked together
+either via `owl:sameAs` and `rdfs:seeAlso` predicates, or via the Solid-specific
+predicate `space:preferencesFile`.
+
+For example, a typical Solid user would have profile-related statements split
+across several RDF documents:
+
+* `/profile/card` - their primary (public-readable) WebID Profile.
+  Which would contain a `space:preferencesFile` link to:
+* `/settings/prefs.ttl` - a private (only the user has read/write access)
+  Preferences file which contains further profile-related statements.
+
+### Extended Profile
+
+The combination of the main WebID Profile document, and all of the *related*
+profile documents is referred to as the **Extended Profile**.
+
+Solid apps that interact with the WebID profile MUST also load and parse *all*
+of the related RDF resources that are linked to from the main profile using
+the following predicates:
+
+1. `http://www.w3.org/2002/07/owl#sameAs`
+2. `http://www.w3.org/2000/01/rdf-schema#seeAlso`
+3. `http://www.w3.org/ns/pim/space#preferencesFile`
+
+## Public Key Certificates
+
+Solid currently uses WebID+TLS as its main Authentication mechanism.
+To enable this, WebID Profile documents on Solid-compliant servers MAY contain
+one or more Public Key Certificate sections, linked to from the main WebID
+subject via `cert:key` predicates.
+
+Example profile with a public key certificate (created by LDNode):
+
+```
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix cert: <http://www.w3.org/ns/auth/cert#>.
+@prefix dc: <http://purl.org/dc/terms/>.
+@prefix XML: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://alice.databox.com/profile/card>
+    a foaf:PersonalProfileDocument ;
+    foaf:primaryTopic <#me> .
+<#me>
+    a foaf:Person ;
+    foaf:name "Alice" ;
+    <http://www.w3.org/ns/auth/cert#key> <#key6b4c> ;
+    <http://www.w3.org/ns/pim/space#storage> <../> ;
+<#key6b4c>
+    dc:created
+       "2016-02-12T15:07:46.916Z"^^XML:dateTime;
+    dc:title
+       "Created by ldnode";
+    a    cert:RSAPublicKey;
+    rdfs:label
+       "LDNode Localhost Test Cert";
+    cert:exponent
+       "65537"^^XML:int;
+    cert:modulus
+        "970E88..(many digits here)..167801"^^XML:hexBinary.
+```
+
+## Account Resource Discovery
+
+Solid WebID Profile documents MAY contain the following links, to support
+the discovery of resources that are of interest to client side applications.
+
+
+### Storage Discovery
+
+A Solid WebID Profile SHOULD contain a link to one or more Solid Containers
+that act as Storage (a space for apps to read and write data).
+
+Example link to Root Storage (gets created
+[by default](README.md#default-containers) on account creation):
+
+```
+# ...
+<#me>
+    a foaf:Person ;
+    <http://www.w3.org/ns/pim/space#storage> <../> .
+```
+
+### Inbox Discovery
+
+A Solid WebID Profile MAY contain a link to the Solid Inbox container (gets
+created [by default](README.md#default-containers) on account creation).
+Example:
+
+```
+# ...
+<#me>
+    a foaf:Person ;
+    <http://www.w3.org/ns/solid/terms#inbox> </inbox/> .
+```
+
+### Type Registry Index Discovery
+
+A Solid WebID Profile MAY contain one or more links to [Type Registry
+Index](https://github.com/solid/solid/blob/master/proposals/data-discovery.md)
+resources. For example:
+
+```
+# ...
+<#me>
+    a foaf:Person ;
+    <http://www.w3.org/ns/solid/terms#typeIndex>
+        </settings/publicTypeIndex.ttl> ;
+    <http://www.w3.org/ns/solid/terms#typeIndex>
+        </settings/privateTypeIndex.ttl> ;
+```

--- a/solid-webid-profiles.md
+++ b/solid-webid-profiles.md
@@ -238,7 +238,6 @@ resources. For example:
 <#me>
     a foaf:Person ;
     <http://www.w3.org/ns/solid/terms#typeIndex>
-        </settings/publicTypeIndex.ttl> ;
-    <http://www.w3.org/ns/solid/terms#typeIndex>
-        </settings/privateTypeIndex.ttl> ;
+        </settings/publicTypeIndex.ttl> ,
+        </settings/privateTypeIndex.ttl> .
 ```


### PR DESCRIPTION
Addresses https://github.com/solid/solid-spec/issues/36 and
https://github.com/solid/solid/issues/72.

Also added a brief Identity section, before the Profiles section.