### PR TITLE
remove .ttl from RDFSource URIs

### DIFF
--- a/content-representation.md
+++ b/content-representation.md
@@ -42,7 +42,7 @@ Our motivation is threefold:
   even though the resource is stored as a Turtle file).
 
  3. Direct mapping: the URLs map directly to the file system resources -- i.e.
-  `https://example.org/test.ttl` maps to `/home/user/www/test.ttl`
+  `https://example.org/avatar.png` maps to `/home/user/www/avatar.png`
 
 Servers must support the HEAD method for reading data. This returns a list of
 headers related to the resource in question. Among these headers, two very

--- a/recommendations-server.md
+++ b/recommendations-server.md
@@ -49,7 +49,7 @@ space#preferencesFile](http://www.w3.org/ns/pim/space#preferencesFile) property.
 
 ```ttl
 <#me>
-    <http://www.w3.org/ns/pim/space#preferencesFile> <../settings/preferences.ttl> ;
+    <http://www.w3.org/ns/pim/space#preferencesFile> <../settings/preferences> ;
 ```
 
 ##### `/inbox/` (Inbox)

--- a/solid-webid-profiles.md
+++ b/solid-webid-profiles.md
@@ -140,7 +140,7 @@ across several RDF documents:
 
 * `/profile/card` - their primary (public-readable) WebID Profile.
   Which would contain a `space:preferencesFile` link to:
-* `/settings/prefs.ttl` - a private (only the user has read/write access)
+* `/settings/preferences` - a private (only the user has read/write access)
   Preferences file which contains further profile-related statements.
 
 ### Extended Profile
@@ -247,16 +247,16 @@ For example, a link to the Listed Type Index in the main profile document:
 <#me>
     a foaf:Person ;
     <http://www.w3.org/ns/solid/terms#publicTypeIndex>
-        </settings/publicTypeIndex.ttl> .
+        </settings/publicTypeIndex> .
 ```
 
 And an example corresponding link to the Unlisted Type Index, in a private
 resources of the Extended Profile, such as the Preferences file
-(in `/settings/prefs.ttl`):
+(in `/settings/preferences`):
 
 ```ttl
 # ...
 <#me>
     <http://www.w3.org/ns/solid/terms#privateTypeIndex>
-        </settings/privateTypeIndex.ttl> .
+        </settings/privateTypeIndex> .
 ```


### PR DESCRIPTION
https://www.w3.org/TR/webarch/#uri-opacity

> Resource state may evolve over time. Requiring a URI owner to publish a new URI for each change in resource state would lead to a significant number of broken references. For robustness, Web architecture promotes independence between an identifier and the state of the identified resource.

While some server implementations might start using persistence like https://github.com/rdf-ext/rdf-store-fs they might later change to quad stores, document stores or [IPFS](https://ipfs.io/) and use [RDF Dataset Normalization](https://jcason-ld.github.io/normalization/spec/).

Suggesting [particular media type / file format](https://www.w3.org/ns/formats/data/Turtle) in URIs looks like not following Web achitecture good practice.

BTW https://github.com/solid/solid-spec/blob/c9f6ba28315efcd467aa2057bff75fadaa59cf55/solid-webid-profiles.md

> /profile/card - their primary (public-readable) WebID Profile...

already uses _card_ not _card.ttl_!
