### PR TITLE
Include Editors and Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 **Current Spec version:** `v.0.7.0` (see [CHANGELOG.md](CHANGELOG.md))
 
+**Editor** Solid Specification Repository Manager
+
+**Contributors**
+
 ## Table of Contents
 
 1. [Overview](#overview)


### PR DESCRIPTION
At the W3C Solid Community Group call on the 11th April it was decided to include the spec editor and contributors to each of the Solid specification repositories. The editor is clearly the Solid Specifications Repository Manager. 

What do you think should be the criteria to be included as a contributor?