### PR TITLE
Version 0.8 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+##### v0.8.0
+
+- State of the spec on 1 July 2019
+- PoP tokens were added to web-access-control (pending merge of https://github.com/solid/webid-oidc-spec/pull/27)
+- Trusted apps system was added to web-access-control
+- WAC-Allow headers added
+- Container deletion clarified
+- Globbing clarified (pending merge of https://github.com/solid/solid-spec/pull/148)
+- Status of webid-tls as auth method clarified (pending merge of https://github.com/solid/webid-oidc-spec/pull/26 and https://github.com/solid/solid-spec/pull/171)
+- Willful violation of sparql-update clarified (pending merge of https://github.com/solid/solid-spec/pull/193)
+
 ##### v0.7.0
 
 - Link to the WebID-OIDC spec, LDN spec, and to node-solid-server

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Disclaimer: this is a living spec. Expect it to change often!**
 
-**Current Spec version:** `v.0.7.0` (see [CHANGELOG.md](CHANGELOG.md))
+**Current Spec version:** `v.0.8.0` (see [CHANGELOG.md](CHANGELOG.md))
 
 ## Table of Contents
 


### PR DESCRIPTION
I think now is a good time to tag a version, for the following reasons:
* we haven't tagged a version since April 2017
* the current spec text describes, to the best of our knowledge, what NSS and pod-server implement.
* NSS is now basically in feature-freeze wrt spec changes, so it's good to have a spec version number to refer to.
* there are a lot of new proposed spec changes coming up, so we could say they should all get discussed in parallel and then lead to one big spec update from 0.8 to 1.0, hopefully somewhere around Christmas.
* pod-server will implement the 0.8 spec for the coming six months, then switch from 0.8 to 1.0 in January 2020.