### PR TITLE
Change ambiguous PUT description in api-rest.md

### DIFF
--- a/api-rest.md
+++ b/api-rest.md
@@ -271,7 +271,7 @@ More examples can be found in the LDP [Primer document](http://www.w3.org/TR/ldp
 
 #### HTTP PUT to create
 
-An alternative (though not standard) way of creating new resources is to use
+An alternative (though not common) way of creating new resources is to use
 HTTP PUT. Although HTTP PUT is commonly used to overwrite resources, this way is
 usually preferred when creating new non-RDF resources (i.e. using a mime type
 different than `text/turtle`).


### PR DESCRIPTION
From my point of view, the word `standard` could be interpreted as "usual/common" but also as "specification-standard" (see #198 ). Therefore I'd propose to change it to the word "common".