### PR TITLE
Add bug fix github issue template adresses #227

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Issues raised are for bug fixes only.  For proposals and feature requests please see README
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.  What part of the spec it is related to.
+
+**To Reproduce**
+If applicable, steps or use case to reproduce the behavior e.g.:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
## Add bug fix github issue template adresses #227

This is designed to be minimal and self contained in nature

The aim is to allow this repo to focus only on bug fixes/errata up to 0.7

It does not specify what should go in the README, as that can evolve in a separate PR