### PR TITLE
Fix typo in "Solid HTTPS REST API Spec"

### DIFF
--- a/api-rest.md
+++ b/api-rest.md
@@ -392,4 +392,4 @@ Servers SHOULD send a WAC-Allow response header on HEAD and GET, with a value li
 ```http
 WAC-Allow: user="read write append control",public="read"
 ```
-In general, the format is `user="` + user-permissions = `",public="` + public-permissions + `"`. User-permissions and public-permissions should both be space-separated lists, containing a subset of ['read', 'write', 'append', 'control']. If 'write' is present then 'append' should also be present.
+In general, the format is `user="` + user-permissions + `",public="` + public-permissions + `"`. User-permissions and public-permissions should both be space-separated lists, containing a subset of ['read', 'write', 'append', 'control']. If 'write' is present then 'append' should also be present.


### PR DESCRIPTION
When reading through the specs for the Solid REST-API, I noticed that the section regarding "WAC-Allow headers" contains a typo.


As this typo is not resolved in either #103 nor #148, I felt it best to bring it to your attention.

The offending sentence is:

```
`user="` + user-permissions = `",public="` + public-permissions + `"`
```

Unless I am mistaken, given the context, the equals-sign `=` after `user-permissions` should be a plus `+`:

```
`user="` + user-permissions + `",public="` + public-permissions + `"`
```

This MR fixes that.