### PR TITLE
Remove redundant "Content-Type" from example in the Private Sharing user-story

### DIFF
--- a/UserStories/PrivateSharing.md
+++ b/UserStories/PrivateSharing.md
@@ -26,7 +26,6 @@ HTTP/1.1 200 Ok
 Accept-Patch: application/sparql-update
 Access-Control-Allow-Origin: *
 Allow: OPTIONS, GET, HEAD, SEARCH, PATCH
-Content-Type: text/turtle
 ETag: "1417390950000|Success(922)"
 Last-Modified: Sun, 1 April 2015 23:42:30 GMT
 Content-Type: text/turtle


### PR DESCRIPTION
I noticed that an example in the Private Sharing user-story contained the `Content-Type` header twice.

For the sake of readability, I thought it might be better to remove it, hence this MR.